### PR TITLE
Feature/loosened config keys regex

### DIFF
--- a/src/Service/AbstractServiceFactory.php
+++ b/src/Service/AbstractServiceFactory.php
@@ -17,8 +17,11 @@ class AbstractServiceFactory implements AbstractFactoryInterface
      *
      * @return bool
      */
-    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
-    {
+    public function canCreateServiceWithName(
+        ServiceLocatorInterface $serviceLocator,
+        $name,
+        $requestedName
+    ) {
         return false !== $this->getFactoryMapping($serviceLocator, $requestedName);
     }
 
@@ -32,7 +35,12 @@ class AbstractServiceFactory implements AbstractFactoryInterface
     {
         $matches = [];
 
-        if (!preg_match('/^rabbitmq\.(?P<serviceType>[a-z0-9_]+)\.(?P<serviceName>[a-z0-9_\-A-Z]+)$/', $name, $matches)) {
+        if (!preg_match(
+            '/^rabbitmq\.(?P<serviceType>[a-z0-9_]+)\.(?P<serviceName>[a-z0-9_\-A-Z]+)$/',
+            $name,
+            $matches
+        )
+        ) {
             return false;
         }
 
@@ -40,7 +48,11 @@ class AbstractServiceFactory implements AbstractFactoryInterface
         $serviceType = $matches['serviceType'];
         $serviceName = $matches['serviceName'];
 
-        if (!isset($config['rabbitmq_factories'][$serviceType], $config['rabbitmq'][$serviceType][$serviceName])) {
+        if (!isset(
+            $config['rabbitmq_factories'][$serviceType],
+            $config['rabbitmq'][$serviceType][$serviceName]
+        )
+        ) {
             return false;
         }
 
@@ -60,8 +72,11 @@ class AbstractServiceFactory implements AbstractFactoryInterface
      *
      * @return mixed
      */
-    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
-    {
+    public function createServiceWithName(
+        ServiceLocatorInterface $serviceLocator,
+        $name,
+        $requestedName
+    ) {
         $mappings = $this->getFactoryMapping($serviceLocator, $requestedName);
 
         if (!$mappings) {

--- a/src/Service/AbstractServiceFactory.php
+++ b/src/Service/AbstractServiceFactory.php
@@ -32,7 +32,7 @@ class AbstractServiceFactory implements AbstractFactoryInterface
     {
         $matches = [];
 
-        if (!preg_match('/^rabbitmq\.(?P<serviceType>[a-z0-9_]+)\.(?P<serviceName>[a-z0-9_]+)$/', $name, $matches)) {
+        if (!preg_match('/^rabbitmq\.(?P<serviceType>[a-z0-9_]+)\.(?P<serviceName>[a-z0-9_\-A-Z]+)$/', $name, $matches)) {
             return false;
         }
 

--- a/tests/unit/Controller/ConsumerControllerTest.php
+++ b/tests/unit/Controller/ConsumerControllerTest.php
@@ -16,7 +16,11 @@ class ConsumerControllerTest extends AbstractConsoleControllerTestCase
 
     public function testDispatchWithTestConsumer()
     {
-        $consumer = static::getMock('RabbitMqModule\Consumer', array('consume'), array(), '', false);
+        $consumer = static::getMockBuilder('RabbitMqModule\Consumer')
+            ->setMethods(['consume'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $consumer
             ->expects(static::once())
             ->method('consume');
@@ -45,7 +49,10 @@ class ConsumerControllerTest extends AbstractConsoleControllerTestCase
 
     public function testStopConsumerController()
     {
-        $consumer = static::getMock('RabbitMqModule\Consumer', ['forceStopConsumer', 'stopConsuming'], [], '', false);
+        $consumer = static::getMockBuilder('RabbitMqModule\Consumer')
+            ->setMethods(['forceStopConsumer', 'stopConsuming'])
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $consumer->expects(static::once())
             ->method('forceStopConsumer');
@@ -74,7 +81,11 @@ class ConsumerControllerTest extends AbstractConsoleControllerTestCase
 
     public function testDispatchWithoutSignals()
     {
-        $consumer = static::getMock('RabbitMqModule\Consumer', array('consume'), array(), '', false);
+        $consumer = static::getMockBuilder('RabbitMqModule\Consumer')
+            ->setMethods(['consume'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $consumer
             ->expects(static::once())
             ->method('consume');

--- a/tests/unit/Controller/RpcServerControllerTest.php
+++ b/tests/unit/Controller/RpcServerControllerTest.php
@@ -15,7 +15,11 @@ class RpcServerControllerTest extends AbstractConsoleControllerTestCase
 
     public function testDispatchWithTestConsumer()
     {
-        $consumer = static::getMock('RabbitMqModule\RpcServer', array('consume'), array(), '', false);
+        $consumer = static::getMockBuilder('RabbitMqModule\RpcServer')
+            ->setMethods(['consume'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $consumer
             ->expects(static::once())
             ->method('consume');

--- a/tests/unit/Controller/StdInProducerControllerTest.php
+++ b/tests/unit/Controller/StdInProducerControllerTest.php
@@ -15,7 +15,11 @@ class StdInProducerControllerTest extends AbstractConsoleControllerTestCase
 
     public function testDispatchWithTestProducer()
     {
-        $producer = static::getMock('RabbitMqModule\Producer', array('publish'), array(), '', false);
+        $producer = static::getMockBuilder('RabbitMqModule\Producer')
+            ->setMethods(['publish'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $producer
             ->expects(static::once())
             ->method('publish')

--- a/tests/unit/Service/AbstractServiceFactoryTest.php
+++ b/tests/unit/Service/AbstractServiceFactoryTest.php
@@ -72,8 +72,6 @@ class AbstractServiceFactoryTest extends PHPUnit_Framework_TestCase
     {
         $sm = $this->serviceManager;
         $factory = new AbstractServiceFactory();
-        static::assertTrue(
-            $factory->createServiceWithName($sm, 'rabbitmq.unknown-key.foo', 'rabbitmq.unknown-key.foo')
-        );
+        $factory->createServiceWithName($sm, 'rabbitmq.unknown-key.foo', 'rabbitmq.unknown-key.foo');
     }
 }

--- a/tests/unit/Service/AbstractServiceFactoryTest.php
+++ b/tests/unit/Service/AbstractServiceFactoryTest.php
@@ -62,8 +62,10 @@ class AbstractServiceFactoryTest extends PHPUnit_Framework_TestCase
     public function testItSuccessfullyCreatesConfiguredService()
     {
         static::assertTrue(
-            $this->factory->createServiceWithName($this->serviceManager,
-                'rabbitmq.producer.bar', 'rabbitmq.producer.bar'
+            $this->factory->createServiceWithName(
+                $this->serviceManager,
+                'rabbitmq.producer.bar',
+                'rabbitmq.producer.bar'
             )
         );
     }


### PR DESCRIPTION
Summary:
- added ability to use dashes and upper case letters in service names
- removed deprecated methods from unit tests
- fixed and updated tests for AbstractServiceFactory
