### PR TITLE
Fix work with queue arguments in queue_declare

### DIFF
--- a/src/BaseAmqp.php
+++ b/src/BaseAmqp.php
@@ -9,6 +9,7 @@ use PhpAmqpLib\Connection\AbstractConnection;
 use RabbitMqModule\Options\Exchange as ExchangeOptions;
 use RabbitMqModule\Options\Queue as QueueOptions;
 use RabbitMqModule\Service\SetupFabricAwareInterface;
+use AMQPTable;
 
 abstract class BaseAmqp implements SetupFabricAwareInterface
 {
@@ -199,7 +200,7 @@ abstract class BaseAmqp implements SetupFabricAwareInterface
         );
 
         $routingKeys = $queueOptions->getRoutingKeys();
-        if (empty($routingKeys)) {
+        if (! \count($routingKeys)) {
             $routingKeys = [''];
         }
         foreach ($routingKeys as $routingKey) {

--- a/src/BaseAmqp.php
+++ b/src/BaseAmqp.php
@@ -185,6 +185,7 @@ abstract class BaseAmqp implements SetupFabricAwareInterface
         }
 
         $exchangeOptions = $this->getExchangeOptions();
+        $arguments = $queueOptions->getArguments();
 
         [$queueName] = $this->getChannel()->queue_declare(
             $queueOptions->getName(),
@@ -193,12 +194,12 @@ abstract class BaseAmqp implements SetupFabricAwareInterface
             $queueOptions->isExclusive(),
             $queueOptions->isAutoDelete(),
             $queueOptions->isNoWait(),
-            $queueOptions->getArguments(),
+            $arguments ? new AMQPTable($arguments) : [],
             $queueOptions->getTicket()
         );
 
         $routingKeys = $queueOptions->getRoutingKeys();
-        if (! \count($routingKeys)) {
+        if (empty($routingKeys)) {
             $routingKeys = [''];
         }
         foreach ($routingKeys as $routingKey) {

--- a/src/BaseAmqp.php
+++ b/src/BaseAmqp.php
@@ -9,7 +9,7 @@ use PhpAmqpLib\Connection\AbstractConnection;
 use RabbitMqModule\Options\Exchange as ExchangeOptions;
 use RabbitMqModule\Options\Queue as QueueOptions;
 use RabbitMqModule\Service\SetupFabricAwareInterface;
-use AMQPTable;
+use PhpAmqpLib\Wire\AMQPTable;
 
 abstract class BaseAmqp implements SetupFabricAwareInterface
 {
@@ -159,7 +159,7 @@ abstract class BaseAmqp implements SetupFabricAwareInterface
         foreach ($binds as $bind) {
             $this->declareExchange($bind->getExchange());
             $routingKeys = $bind->getRoutingKeys();
-            if (! \count($routingKeys)) {
+            if (empty($routingKeys)) {
                 $routingKeys = [''];
             }
             foreach ($routingKeys as $routingKey) {
@@ -200,7 +200,7 @@ abstract class BaseAmqp implements SetupFabricAwareInterface
         );
 
         $routingKeys = $queueOptions->getRoutingKeys();
-        if (! \count($routingKeys)) {
+        if (empty($routingKeys)) {
             $routingKeys = [''];
         }
         foreach ($routingKeys as $routingKey) {

--- a/tests/unit/BaseAmqpTest.php
+++ b/tests/unit/BaseAmqpTest.php
@@ -2,87 +2,95 @@
 
 namespace RabbitMqModule;
 
-class BaseAmqpTest extends \PHPUnit\Framework\TestCase
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AbstractConnection;
+use PhpAmqpLib\Wire\AMQPTable;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RabbitMqModule\Options\Exchange as ExchangeOptions;
+use RabbitMqModule\Options\Queue as QueueOptions;
+
+class BaseAmqpTest extends TestCase
 {
     public function testConstructor()
     {
-        $connection = $this->getMockBuilder('PhpAmqpLib\\Connection\\AbstractConnection')
+        $connection = $this->getMockBuilder(AbstractConnection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $channel = $this->getMockBuilder('PhpAmqpLib\\Channel\\AMQPChannel')
+
+        $channel = $this->getMockBuilder(AMQPChannel::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $baseAmqp = $this->getMockBuilder('RabbitMqModule\\BaseAmqp')
+
+        /** @var MockObject|BaseAmqp $baseAmqp */
+        $baseAmqp = $this->getMockBuilder(BaseAmqp::class)
             ->setConstructorArgs([$connection])
             ->setMethods(['__destruct'])
             ->getMock();
 
-        $baseAmqp->method('__destruct');
+        $connection->expects(static::once())
+            ->method('channel')
+            ->willReturn($channel);
 
-        $connection->expects(static::once())->method('channel')->willReturn($channel);
-
-        /** @var \RabbitMqModule\BaseAmqp $baseAmqp */
         static::assertEquals($channel, $baseAmqp->getChannel());
     }
 
     public function testSetChannel()
     {
-        $connection = $this->getMockBuilder('PhpAmqpLib\\Connection\\AbstractConnection')
+        $connection = $this->getMockBuilder(AbstractConnection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $channel = $this->getMockBuilder('PhpAmqpLib\\Channel\\AMQPChannel')
+
+        $channel = $this->getMockBuilder(AMQPChannel::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $baseAmqp = $this->getMockBuilder('RabbitMqModule\\BaseAmqp')
+
+        /** @var MockObject|BaseAmqp $baseAmqp */
+        $baseAmqp = $this->getMockBuilder(BaseAmqp::class)
             ->setConstructorArgs([$connection])
             ->setMethods(['__destruct'])
             ->getMock();
 
-        $baseAmqp->method('__destruct');
-
-        /* @var \RabbitMqModule\BaseAmqp $baseAmqp */
+        /** @var MockObject|AMQPChannel $channel */
         $baseAmqp->setChannel($channel);
+
         static::assertEquals($channel, $baseAmqp->getChannel());
-    }
-
-    protected static function getMethod($name)
-    {
-        $class = new \ReflectionClass('RabbitMqModule\\BaseAmqp');
-        $method = $class->getMethod($name);
-        $method->setAccessible(true);
-
-        return $method;
     }
 
     public function testDestruct()
     {
-        $connection = $this->getMockBuilder('PhpAmqpLib\\Connection\\AbstractConnection')
+        $connection = $this->getMockBuilder(AbstractConnection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $channel = $this->getMockBuilder('PhpAmqpLib\\Channel\\AMQPChannel')
+
+        $channel = $this->getMockBuilder(AMQPChannel::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $baseAmqp = $this->getMockBuilder('RabbitMqModule\\BaseAmqp')
+
+        $baseAmqp = $this->getMockBuilder(BaseAmqp::class)
             ->setConstructorArgs([$connection])
             ->setMethods(null)
             ->getMock();
 
-        $connection->expects(static::once())->method('isConnected')->willReturn(true);
-        $connection->expects(static::once())->method('close');
+        $connection->expects(static::once())
+            ->method('isConnected')
+            ->willReturn(true);
 
+        $connection->expects(static::once())->method('close');
         $channel->expects(static::once())->method('close');
 
-        /* @var \RabbitMqModule\BaseAmqp $baseAmqp */
+        /* @var BaseAmqp $baseAmqp */
         $baseAmqp->setChannel($channel);
         $baseAmqp->__destruct();
     }
 
     public function testReconnect()
     {
-        $connection = $this->getMockBuilder('PhpAmqpLib\\Connection\\AbstractConnection')
+        $connection = $this->getMockBuilder(AbstractConnection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $baseAmqp = $this->getMockBuilder('RabbitMqModule\\BaseAmqp')
+
+        $baseAmqp = $this->getMockBuilder(BaseAmqp::class)
             ->setConstructorArgs([$connection])
             ->setMethods(['__destruct'])
             ->getMock();
@@ -95,10 +103,11 @@ class BaseAmqpTest extends \PHPUnit\Framework\TestCase
 
     public function testReconnectWhenConnected()
     {
-        $connection = $this->getMockBuilder('PhpAmqpLib\\Connection\\AbstractConnection')
+        $connection = $this->getMockBuilder(AbstractConnection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $baseAmqp = $this->getMockBuilder('RabbitMqModule\\BaseAmqp')
+
+        $baseAmqp = $this->getMockBuilder(BaseAmqp::class)
             ->setConstructorArgs([$connection])
             ->setMethods(['__destruct'])
             ->getMock();
@@ -107,5 +116,156 @@ class BaseAmqpTest extends \PHPUnit\Framework\TestCase
         $connection->expects(static::never())->method('reconnect');
 
         $baseAmqp->reconnect();
+    }
+
+    public function testQueueOptions()
+    {
+        $baseAmqp = $this->getMockBuilder(BaseAmqp::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['__destruct'])
+            ->getMock();
+
+        $options = new QueueOptions();
+
+        $baseAmqp->setQueueOptions($options);
+        static::assertEquals($options, $baseAmqp->getQueueOptions());
+    }
+
+    public function testExchangeOptions()
+    {
+        $baseAmqp = $this->getMockBuilder(BaseAmqp::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['__destruct'])
+            ->getMock();
+
+        $options = new ExchangeOptions();
+
+        $baseAmqp->setExchangeOptions($options);
+        static::assertEquals($options, $baseAmqp->getExchangeOptions());
+    }
+
+    /**
+     * @param bool $isEnabled
+     *
+     * @dataProvider getDataProviderForAutoSetupFabricEnabled
+     */
+    public function testAutoSetupFabricEnabled(bool $isEnabled)
+    {
+        $baseAmqp = $this->getMockBuilder(BaseAmqp::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['__destruct'])
+            ->getMock();
+
+        $baseAmqp->setAutoSetupFabricEnabled($isEnabled);
+        static::assertEquals($isEnabled, $baseAmqp->isAutoSetupFabricEnabled());
+    }
+
+    public function getDataProviderForAutoSetupFabricEnabled(): array
+    {
+        return [
+            [true],
+            [false],
+        ];
+    }
+
+    /**
+     * @param array $exchangeData
+     * @param array $queueData
+     *
+     * @dataProvider getDataProviderForSetupFabric
+     */
+    public function testSetupFabricWithoutBinds(array $exchangeData, array $queueData)
+    {
+        $channel = $this->getMockBuilder(AMQPChannel::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['exchange_declare', 'queue_declare', 'queue_bind'])
+            ->getMock();
+        $channel->expects(static::once())
+            ->method('exchange_declare')
+            ->with(
+                $exchangeData['name'],
+                $exchangeData['type'],
+                $exchangeData['passive'],
+                $exchangeData['durable'],
+                $exchangeData['auto_delete'],
+                $exchangeData['internal'],
+                $exchangeData['no_wait'],
+                $exchangeData['arguments'],
+                $exchangeData['ticket']
+            );
+        $channel->expects(static::once())
+            ->method('queue_declare')
+            ->with(
+                $queueData['name'],
+                $queueData['passive'],
+                $queueData['durable'],
+                $queueData['exclusive'],
+                $queueData['auto_delete'],
+                $queueData['no_wait'],
+                new AMQPTable($queueData['arguments']),
+                $queueData['ticket']
+            )
+            ->willReturn([$queueData['name']]);
+
+        $routingKeys = $queueData['routing_keys'] ?? [''];
+        $channel->expects(static::exactly(count($routingKeys)))
+            ->method('queue_bind')
+            ->withConsecutive(...array_map(function ($routingKey) use ($queueData, $exchangeData) {
+                return [
+                    $queueData['name'],
+                    $exchangeData['name'],
+                    $routingKey,
+                ];
+            }, $routingKeys));
+
+        $baseAmqp = $this->getMockBuilder(BaseAmqp::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['__destruct', 'getChannel'])
+            ->getMock();
+        $baseAmqp->expects(static::any())
+            ->method('getChannel')
+            ->willReturn($channel);
+
+        $queueOptions = new QueueOptions($queueData);
+        $baseAmqp->setQueueOptions($queueOptions);
+
+        $exchangeOptions = new ExchangeOptions($exchangeData);
+        $baseAmqp->setExchangeOptions($exchangeOptions);
+
+        $baseAmqp->setupFabric();
+
+        // declare only once
+        $baseAmqp->setupFabric();
+    }
+
+    public function getDataProviderForSetupFabric(): array
+    {
+        return [
+            [
+                [
+                    'declare'     => true,
+                    'name'        => 'some_exchange_name',
+                    'type'        => 'some_exchange_type',
+                    'passive'     => true,
+                    'durable'     => true,
+                    'auto_delete' => true,
+                    'internal'    => true,
+                    'no_wait'     => true,
+                    'arguments'   => [],
+                    'ticket'      => 1,
+                ],
+                [
+                    'name'         => 'some_queue_name',
+                    'passive'      => true,
+                    'durable'      => true,
+                    'exclusive'    => true,
+                    'auto_delete'  => true,
+                    'no_wait'      => true,
+                    'arguments'    => ['some_argument'],
+                    'ticket'       => 1,
+                    'routing_keys' => ['some_key'],
+                ],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
To work with queue arguments, we need to wrap arguments by \PhpAmqpLib\Wire\AMQPTable.
Exception will be:
```
PhpAmqpLib\Exception\AMQPOutOfRangeException

File:
vendor/php-amqplib/php-amqplib/PhpAmqpLib/Wire/AMQPAbstractCollection.php:417
Message:
AMQP-rabbit doesn't define data of type []
```